### PR TITLE
Fix tool calls parts not available until a text message part appears

### DIFF
--- a/packages/shared/src/utils/call-api.ts
+++ b/packages/shared/src/utils/call-api.ts
@@ -55,6 +55,7 @@ export async function callApi(streamTextOptions: Omit<StreamTextOptions, 'onEven
             },
             type: 'tool-call',
           })
+          message.content = message.content as string ?? ''
           break
         }
         case 'tool-call-delta': {


### PR DESCRIPTION
This PR replaces [this one](https://github.com/moeru-ai/xsai-use/pull/15), and aims to fix the fact that no part of the message other than user prompt is available when LLM decides to start with tool calls, and this, until it writes text.